### PR TITLE
Logging improvement

### DIFF
--- a/src/main/java/org/hidetake/stubyaml/app/ReloadableRouter.java
+++ b/src/main/java/org/hidetake/stubyaml/app/ReloadableRouter.java
@@ -1,6 +1,5 @@
 package org.hidetake.stubyaml.app;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.*;
 import reactor.core.publisher.Mono;
@@ -9,7 +8,6 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.web.reactive.function.server.RequestPredicates.all;
 import static org.springframework.web.reactive.function.server.ServerResponse.status;
 
-@Slf4j
 @Component
 public class ReloadableRouter implements RouterFunction<ServerResponse> {
     private volatile RouterFunction<ServerResponse> current =
@@ -17,7 +15,6 @@ public class ReloadableRouter implements RouterFunction<ServerResponse> {
             all(), request -> status(INTERNAL_SERVER_ERROR).syncBody("Initializing..."));
 
     public void reload(RouterFunction<ServerResponse> routerFunction) {
-        log.info("Reloading router function... {} -> {}", current, routerFunction);
         current = routerFunction;
     }
 

--- a/src/main/java/org/hidetake/stubyaml/app/RouteHandler.java
+++ b/src/main/java/org/hidetake/stubyaml/app/RouteHandler.java
@@ -1,14 +1,13 @@
 package org.hidetake.stubyaml.app;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.hidetake.stubyaml.model.execution.CompiledRoute;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
-@Slf4j
 @RequiredArgsConstructor
 @Component
 public class RouteHandler {
@@ -25,5 +24,24 @@ public class RouteHandler {
                 route.findRule(requestContext)
                     .map(rule -> responseRenderer.render(rule.getResponse(), requestContext))
                     .orElse(NO_RULE_MATCHED));
+    }
+
+    public Proxy proxy(CompiledRoute route) {
+        return new Proxy(route);
+    }
+
+    @RequiredArgsConstructor
+    public class Proxy implements HandlerFunction<ServerResponse> {
+        private final CompiledRoute route;
+
+        @Override
+        public Mono<ServerResponse> handle(ServerRequest request) {
+            return RouteHandler.this.handle(route, request);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("(%d rule(s))", route.getRules().size());
+        }
     }
 }

--- a/src/main/java/org/hidetake/stubyaml/app/RouteRegistrar.java
+++ b/src/main/java/org/hidetake/stubyaml/app/RouteRegistrar.java
@@ -59,10 +59,9 @@ public class RouteRegistrar {
             .flatMap(routeSource -> {
                 try {
                     return routeCompiler.compile(routeSource, baseDirectory)
-                        .map(compiledRoute -> Stream.of(
-                            RouterFunctions.route(
-                                compiledRoute.getRequestPredicate(),
-                                request -> routeHandler.handle(compiledRoute, request))))
+                        .map(compiledRoute -> Stream.of(RouterFunctions.route(
+                            compiledRoute.getRequestPredicate(),
+                            routeHandler.proxy(compiledRoute))))
                         .orElse(Stream.empty());
                 } catch (Exception e) {
                     exceptions.add(e);

--- a/src/main/java/org/hidetake/stubyaml/model/IllegalRouteException.java
+++ b/src/main/java/org/hidetake/stubyaml/model/IllegalRouteException.java
@@ -1,0 +1,19 @@
+package org.hidetake.stubyaml.model;
+
+import lombok.Getter;
+import org.hidetake.stubyaml.model.yaml.RouteSource;
+
+@Getter
+public class IllegalRouteException extends RuntimeException {
+    private final RouteSource routeSource;
+
+    public IllegalRouteException(RouteSource routeSource, String message) {
+        super(String.format("Error in %s:\n%s", routeSource, message));
+        this.routeSource = routeSource;
+    }
+
+    public IllegalRouteException(RouteSource routeSource, Throwable throwable) {
+        super(String.format("Error in %s:\n%s", routeSource, throwable));
+        this.routeSource = routeSource;
+    }
+}

--- a/src/main/java/org/hidetake/stubyaml/model/IllegalRuleException.java
+++ b/src/main/java/org/hidetake/stubyaml/model/IllegalRuleException.java
@@ -1,0 +1,19 @@
+package org.hidetake.stubyaml.model;
+
+import lombok.Getter;
+import org.hidetake.stubyaml.model.yaml.RouteSource;
+
+@Getter
+public class IllegalRuleException extends RuntimeException {
+    private final RouteSource routeSource;
+
+    public IllegalRuleException(String message, RouteSource routeSource) {
+        super(String.format("Error in %s:\n%s", routeSource, message));
+        this.routeSource = routeSource;
+    }
+
+    public IllegalRuleException(String message, RouteSource routeSource, Throwable cause) {
+        super(String.format("Error in %s:\n%s\n%s", routeSource, message, cause), cause);
+        this.routeSource = routeSource;
+    }
+}

--- a/src/main/java/org/hidetake/stubyaml/model/ResponseCompiler.java
+++ b/src/main/java/org/hidetake/stubyaml/model/ResponseCompiler.java
@@ -1,7 +1,6 @@
 package org.hidetake.stubyaml.model;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.hidetake.stubyaml.model.execution.CompiledResponse;
 import org.hidetake.stubyaml.model.execution.CompiledResponseBody;
@@ -17,27 +16,26 @@ import static java.util.stream.Collectors.toList;
 import static org.hidetake.stubyaml.util.MapUtils.mapValue;
 import static org.springframework.util.Assert.notNull;
 
-@Slf4j
 @RequiredArgsConstructor
 @Component
 public class ResponseCompiler {
     private final ExpressionCompiler expressionCompiler;
     private final TableCompiler tableCompiler;
 
-    public CompiledResponse compile(RouteSource source, Response response) {
+    public CompiledResponse compile(Response response, RouteSource source) {
         notNull(response, "response should not be null");
         notNull(response.getHeaders(), "headers should not be null");
 
         return CompiledResponse.builder()
             .status(response.getStatus())
-            .headers(mapValue(response.getHeaders(), expressionCompiler::compileTemplate))
-            .body(compileBody(source, response))
-            .tables(tableCompiler.compile(response.getTables()))
-            .delay(computeDelay(response))
+            .headers(mapValue(response.getHeaders(), value -> expressionCompiler.compileTemplate(value, source)))
+            .body(compileBody(response, source))
+            .tables(tableCompiler.compile(response.getTables(), source))
+            .delay(computeDelay(response, source))
             .build();
     }
 
-    private CompiledResponseBody compileBody(RouteSource source, Response response) {
+    private CompiledResponseBody compileBody(Response response, RouteSource source) {
         val body = response.getBody();
         val file = response.getFile();
         if (body != null && file != null) {
@@ -47,36 +45,35 @@ public class ResponseCompiler {
             return new CompiledResponseBody.NullBody();
         }
         if (body != null) {
-            return new CompiledResponseBody.PrimitiveBody(compilePrimitiveBody(body));
+            return new CompiledResponseBody.PrimitiveBody(compilePrimitiveBody(body, source));
         } else {
-            val filenameExpression = expressionCompiler.compileTemplate(file);
-            val baseDirectory = source.getYamlFile().getParentFile();
+            val filenameExpression = expressionCompiler.compileTemplate(file, source);
+            val baseDirectory = source.getFile().getParentFile();
             return new CompiledResponseBody.FileBody(filenameExpression, baseDirectory);
         }
     }
 
-    private Object compilePrimitiveBody(Object body) {
+    private Object compilePrimitiveBody(Object body, RouteSource source) {
         if (body instanceof String) {
             val string = (String) body;
-            return expressionCompiler.compileTemplate(string);
+            return expressionCompiler.compileTemplate(string, source);
         } else if (body instanceof List) {
             val list = (List<?>) body;
-            return list.stream().map(this::compilePrimitiveBody).collect(toList());
+            return list.stream().map(item -> compilePrimitiveBody(item, source)).collect(toList());
         } else if (body instanceof Map) {
             val map = (Map<?, ?>) body;
-            return mapValue(map, this::compilePrimitiveBody);
+            return mapValue(map, item -> compilePrimitiveBody(item, source));
         } else {
             return body;
         }
     }
 
-    private Duration computeDelay(Response response) {
+    private Duration computeDelay(Response response, RouteSource source) {
         val delay = response.getDelay();
         if (delay >= 0) {
             return Duration.ofMillis(delay);
         } else {
-            log.warn("Ignored invalid delay {}", delay);
-            return Duration.ZERO;
+            throw new IllegalRuleException("Invalid delay: " + delay, source);
         }
     }
 }

--- a/src/main/java/org/hidetake/stubyaml/model/RuleCompiler.java
+++ b/src/main/java/org/hidetake/stubyaml/model/RuleCompiler.java
@@ -6,8 +6,6 @@ import org.hidetake.stubyaml.model.yaml.RouteSource;
 import org.hidetake.stubyaml.model.yaml.Rule;
 import org.springframework.stereotype.Component;
 
-import static org.springframework.util.Assert.notNull;
-
 @RequiredArgsConstructor
 @Component
 public class RuleCompiler {
@@ -15,10 +13,9 @@ public class RuleCompiler {
     private final ResponseCompiler responseCompiler;
 
     public CompiledRule compile(RouteSource source, Rule rule) {
-        notNull(rule, "rule should not be null");
         return CompiledRule.builder()
-            .when(expressionCompiler.compileExpression(rule.getWhen()))
-            .response(responseCompiler.compile(source, rule.getResponse()))
+            .when(expressionCompiler.compileExpression(rule.getWhen(), source))
+            .response(responseCompiler.compile(rule.getResponse(), source))
             .build();
     }
 }

--- a/src/main/java/org/hidetake/stubyaml/model/yaml/RouteSource.java
+++ b/src/main/java/org/hidetake/stubyaml/model/yaml/RouteSource.java
@@ -16,7 +16,11 @@ import java.util.stream.StreamSupport;
 public class RouteSource {
     private static final Pattern PATH_PATTERN = Pattern.compile("(.+)\\.(.+?)\\.(.+?)$");
 
-    private final File yamlFile;
+    private final File file;
+
+    public String getName() {
+        return file.getPath();
+    }
 
     public Optional<Route> parseName(Path basePath) {
         val relativePath = computeRelativePath(basePath);
@@ -35,7 +39,7 @@ public class RouteSource {
     }
 
     public String computeRelativePath(Path basePath) {
-        val relativePath = basePath.relativize(yamlFile.toPath());
+        val relativePath = basePath.relativize(file.toPath());
         return "/" + StreamSupport.stream(relativePath.spliterator(), false)
             .map(Path::toString)
             .collect(Collectors.joining("/"));

--- a/src/test/groovy/org/hidetake/stubyaml/model/ExpressionCompilerSpec.groovy
+++ b/src/test/groovy/org/hidetake/stubyaml/model/ExpressionCompilerSpec.groovy
@@ -1,5 +1,6 @@
 package org.hidetake.stubyaml.model
 
+import org.hidetake.stubyaml.model.yaml.RouteSource
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -9,7 +10,8 @@ class ExpressionCompilerSpec extends Specification {
     @Unroll
     def 'Template #template should produce #value on evaluated'() {
         when:
-        def compiledExpression = expressionCompiler.compileTemplate(template)
+        def source = new RouteSource(new File('/README.md'))
+        def compiledExpression = expressionCompiler.compileTemplate(template, source)
 
         then:
         compiledExpression?.evaluate {-> new Binding()} == value


### PR DESCRIPTION
You will get the following on access `/`:

```
## 4 ERROR(S)

org.hidetake.stubyaml.model.IllegalRuleException: Error in RouteSource(file=data/invalid/invalid-delay.get.yaml):
Invalid delay: -1
----
org.hidetake.stubyaml.model.IllegalRuleException: Error in RouteSource(file=data/invalid/invalid-template.get.yaml):
Invalid expression: """${// this is an invalid syntax in Groovy template}
"""
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
data/invalid/invalid-template.get.yaml: 2: unexpected char: '"' @ line 2, column 3.
   """
     ^

1 error

----
org.hidetake.stubyaml.model.IllegalRouteException: Error in RouteSource(file=data/invalid/invalid-type.get.yaml):
Cannot create property=response for JavaBean=Rule(when=null, response=null)
 in 'reader', line 1, column 3:
    - response:
      ^
Cannot create property=headers for JavaBean=Response(status=200, headers={}, body=null, file=null, tables=[], delay=0)
 in 'reader', line 3, column 5:
        headers: foo
        ^
No single argument constructor found for interface java.util.Map : null
 in 'reader', line 3, column 14:
        headers: foo
                 ^

 in 'reader', line 3, column 5:
        headers: foo
        ^

----
org.hidetake.stubyaml.model.IllegalRouteException: Error in RouteSource(file=data/invalid/invalid-yaml.get.yaml):
while parsing a block mapping
 in 'reader', line 2, column 5:
        headers:
        ^
expected <block end>, but found BlockEntry
 in 'reader', line 5, column 5:
        - body:
        ^


## 13 ROUTE(S)

(GET && /features/empty-rule) -> (0 rules)
(POST && /features/request-body-type) -> (1 rules)
(POST && /features/request-body-value) -> (1 rules)
(GET && /features/response-json-charset) -> (1 rules)
(GET && /features/status-code) -> (1 rules)
(GET && /groups/1) -> (1 rules)
(GET && /numbers) -> (3 rules)
(GET && /users/{userId}/photo) -> (1 rules)
(POST && /users/{userId}/photo) -> (1 rules)
(DELETE && /users/{userId}) -> (1 rules)
(GET && /users/{userId}) -> (1 rules)
(GET && /users) -> (1 rules)
(POST && /users) -> (1 rules)
```